### PR TITLE
tagit bort onödig css, ändrat storlek och färg

### DIFF
--- a/css/desktopHeader.css
+++ b/css/desktopHeader.css
@@ -44,7 +44,7 @@ header i {
 }
 
 .header-dates h2 {
-  text-shadow: 0 0 0.3rem var(--headerTxt-color);
+  text-shadow: 0 0 0.2rem var(--headerTxt-color);
 }
 
 .header-dates div {
@@ -54,6 +54,6 @@ header i {
 
 @media (max-width: 999px) {
   .header-weather {
-  display: none;
-}
+    display: none;
+  }
 }

--- a/css/mobileAside.css
+++ b/css/mobileAside.css
@@ -136,6 +136,6 @@ aside i {
 .aside-dates {
   margin: 1rem 0 1rem 0;
   width: 100%;
-  font-size: 2rem;
+  font-size: 1.7rem;
   color: white;
 }

--- a/css/mobileHeader.css
+++ b/css/mobileHeader.css
@@ -1,27 +1,3 @@
 header {
   display: none;
 }
-
-header div {
-  display: none;
-}
-
-header p {
-  display: none;
-}
-
-header i {
-  display: none;
-}
-
-.header-dates {
-  display: none;
-}
-
-.header-dates h2 {
-  display: none;
-}
-
-.header-dates div {
-  display: none;
-}

--- a/css/variables.css
+++ b/css/variables.css
@@ -8,5 +8,5 @@
   --aside-background-image: linear-gradient(#191a1a, #717777);
   --toDoCardTxtArea-background-image: linear-gradient(#ffffff, #717777);
   --headerBg-color: #191a1a;
-  --headerTxt-color: rgb(17, 188, 227);
+  --headerTxt-color: #ffffff;
 }


### PR DESCRIPTION
Tog bort onödig css i mobileHeader.css
Ändrade storleken på texten i mobileAside.css så att tid och datum får plats på en rad hela vägen ner till 360px
Ändrade färg på månad och år i desktopHeader.css för verka lite mer enhetligt

Bilder finns nedan för er att se ändringarna.

![image](https://user-images.githubusercontent.com/90764566/174968291-84e22f55-249c-435a-a087-adf123269865.png)
![image](https://user-images.githubusercontent.com/90764566/174968374-7a051471-68ea-4744-9d1e-11c40e75b132.png)
